### PR TITLE
Update owner of action-toolbelt-login to te-0029

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -14,7 +14,7 @@ metadata:
     vtex.com/application-id: VLXF6T5W
 spec:
   lifecycle: stable
-  owner: apps
+  owner: te-0029
   type: gh-action
   dependsOn:
     - component:toolbelt


### PR DESCRIPTION
This PR updates the owner of action-toolbelt-login to te-0029 in the catalog-info.yaml file.