### PR TITLE
chore: add SonarQube scan pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,7 +1,22 @@
 - name: action-toolbelt-login
+  referenceId: PLACEHOLDER
   build:
     provider: dkcicd
     pipelines:
+      - name: node-ci-v2
+        parameters:
+          sonarProjectName: action-toolbelt-login
+          nodeVersion: 20-bookworm
+          nodeCommands:
+            - test -- --coverage
+        runtime:
+          architecture: amd64
+        when:
+          - event: pull_request
+            source: branch
+          - event: push
+            source: branch
+            regex: main
       - name: techdocs-v1
         parameters:
           entityReference: default/component/action-toolbelt-login

--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,5 +1,5 @@
 - name: action-toolbelt-login
-  referenceId: PLACEHOLDER
+  referenceId: VLXF6T5W
   build:
     provider: dkcicd
     pipelines:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint --ext ts .",
     "package": "ncc build --source-map --license licenses.txt",
     "test": "jest",
+    "ci": "yarn install --frozen-lockfile",
     "all": "run-s build lint package test"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- Adds a `node-ci-v2` pipeline to enable SonarQube code quality scanning
- Triggers on pull requests for PR decoration (quality gate comments)

## Context
Part of a rollout to enable SonarQube across VTEX repositories. Runs alongside existing CI pipelines.

## Test plan
- [ ] Pipeline runs successfully on this PR
- [ ] SonarQube project appears at http://sonarqube.vtex.systems/
- [ ] PR decoration (quality gate comment) appears